### PR TITLE
Don't use a buffered statsd client

### DIFF
--- a/adapters/dogstatsd/dogstatsd.go
+++ b/adapters/dogstatsd/dogstatsd.go
@@ -12,7 +12,7 @@ func init() {
 }
 
 func newDogstatsdAdapter(route *router.Route) (router.LogAdapter, error) {
-	c, err := statsd.NewBuffered(route.Address, 1000)
+	c, err := statsd.New(route.Address)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing dogstatsd client: %v", err)
 	}


### PR DESCRIPTION
The buffered statsd client would flood the dogstatd socket every 100ms, and it's not fast enough to keep up. Flushing on every message means no dropped datagrams:

![](http://i.imgur.com/dzL5Q9j.png)

For background, see https://github.com/DataDog/datadog-go/issues/20
