### PR TITLE
Less distinct metrics for dogstatsd

### DIFF
--- a/adapters/dogstatsd/dogstatsd.go
+++ b/adapters/dogstatsd/dogstatsd.go
@@ -1,4 +1,4 @@
-package adapters
+package dogstatsd
 
 import (
 	"fmt"
@@ -52,6 +52,10 @@ func (a *dogstatsdAdapter) inc(m *router.Message) {
 
 // Splits a comma separated list of labels into a map[string]bool.
 func labelsFromString(s string) map[string]bool {
+	if s == "" {
+		return nil
+	}
+
 	labels := make(map[string]bool)
 	for _, name := range strings.Split(s, ",") {
 		labels[name] = true

--- a/adapters/dogstatsd/dogstatsd_test.go
+++ b/adapters/dogstatsd/dogstatsd_test.go
@@ -1,0 +1,27 @@
+package dogstatsd
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestLabelsFromString(t *testing.T) {
+	tests := []struct {
+		in  string
+		out map[string]bool
+	}{
+		{"", nil},
+		{"empire.app.name", map[string]bool{"empire.app.name": true}},
+		{"empire.app.name,empire.app.process", map[string]bool{"empire.app.name": true, "empire.app.process": true}},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			out := labelsFromString(tt.in)
+			if !reflect.DeepEqual(out, tt.out) {
+				t.Fatalf("%v; want %v", out, tt.out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Right now, this metric is super slow in dashboards, and I want to create an anomaly detection alert on logs, but there's currently too many distinct metrics to do that.

This removes the container_id and container_name metrics from the `logspout.*` metrics, and also makes the inclusion of docker labels whitelisted.