### PR TITLE
Add an adapter for datadog logs

### DIFF
--- a/adapters/datadog/datadog.go
+++ b/adapters/datadog/datadog.go
@@ -1,0 +1,101 @@
+package datadog
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log"
+	"net"
+	"os"
+	"reflect"
+	"text/template"
+	"time"
+
+	"github.com/gliderlabs/logspout/router"
+)
+
+func init() {
+	router.AdapterFactories.Register(NewDatadogAdapter, "datadog")
+}
+
+type DatadogAdapter struct {
+	conn        net.Conn
+	route       *router.Route
+	serviceTmpl *template.Template
+}
+
+func NewDatadogAdapter(route *router.Route) (router.LogAdapter, error) {
+	transport, found := router.AdapterTransports.Lookup(route.AdapterTransport("udp"))
+	if !found {
+		return nil, errors.New("bad transport: " + route.Adapter)
+	}
+	conn, err := transport.Dial(route.Address, route.Options)
+	if err != nil {
+		return nil, err
+	}
+
+	service := getopt("DATADOG_SERVICE", "{{.Container.Name}}")
+	serviceTmpl, err := template.New("service").Parse(service)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DatadogAdapter{
+		route:       route,
+		conn:        conn,
+		serviceTmpl: serviceTmpl,
+	}, nil
+}
+
+func (a *DatadogAdapter) Stream(logstream chan *router.Message) {
+	for message := range logstream {
+		buf := new(bytes.Buffer)
+		err := a.serviceTmpl.Execute(buf, message)
+		if err != nil {
+			log.Println("datadog:", err)
+		}
+		service := buf.String()
+
+		raw, err := json.Marshal(&Message{
+			Timestamp: &message.Time,
+			Service:   &service,
+			Source:    &message.Source,
+			Message:   &message.Data,
+			Container: &Container{
+				ID:     &message.Container.ID,
+				Labels: &message.Container.Config.Labels,
+			},
+		})
+		_, err = a.conn.Write(append(raw, []byte("\n")...))
+		if err != nil {
+			log.Println("datadog:", err)
+			if reflect.TypeOf(a.conn).String() != "*net.UDPConn" {
+				return
+			}
+		}
+	}
+}
+
+type Container struct {
+	ID     *string            `json:"id"`
+	Labels *map[string]string `json:"labels"`
+}
+
+// See the documention on "Reserved Attributes" for JSON logs
+//
+// https://docs.datadoghq.com/logs/processing/pipelines/#reserved-attribute-pipeline
+type Message struct {
+	Timestamp *time.Time `json:"timestamp"`
+	Source    *string    `json:"source"`
+	Service   *string    `json:"service,omitempty"`
+	Message   *string    `json:"message"`
+	Container *Container `json:"container"`
+}
+
+func getopt(name, dfault string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		value = dfault
+	}
+	return value
+}

--- a/modules.go
+++ b/modules.go
@@ -4,6 +4,7 @@ import (
 	_ "github.com/gliderlabs/logspout/adapters/raw"
 	_ "github.com/gliderlabs/logspout/transports/tcp"
 	_ "github.com/remind101/logspout-kinesis"
+	_ "github.com/remind101/logspout/adapters/datadog"
 	_ "github.com/remind101/logspout/adapters/dogstatsd"
 	_ "github.com/remind101/logspout/adapters/syslog"
 	_ "github.com/remind101/logspout/transports/udp"


### PR DESCRIPTION
This adds a custom adapter specifically for forwarding docker logs to a datadog udp listener as described here: https://docs.datadoghq.com/logs/log_collection/?tab=streamlogsfromtcpudp

This forwards the logs in JSON format, using the reserved fields convention described here: https://docs.datadoghq.com/logs/processing/pipelines/#reserved-attribute-pipeline

This is better than using something like the `syslog` adapter, since these JSON fields are automatically parsed by datadog without having to define any custom pipelines.